### PR TITLE
feat: auto-generate and persist optional TalkToMe bridge id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,14 @@ dist
 baresip/config/accounts
 baresip/config/contacts
 baresip/config/autoconnect.json
+<<<<<<< HEAD
+=======
+baresip/config/talktome-bridge.json
+baresip/config/talktome-bridge.identity.json
+baresip/config/.talktome-bridge.json.*.tmp
+baresip/config/.talktome-bridge.identity.json.*.tmp
+baresip/config/.talktome-bridge.json.transaction-journal
+>>>>>>> 4af7e3c (feat: auto-generate and persist optional TalkToMe bridge id)
 baresip/config/current_contact
 baresip/config/call-history.json
 baresip/.asoundrc

--- a/README.docker.md
+++ b/README.docker.md
@@ -259,7 +259,7 @@ docker compose -f compose.build-from-source.yaml up -d
 | `TALKTOME_BRIDGE_ENABLED` | `false` | Global talktome bridge gate; also passed without secrets to baresip as a Compose recreation marker |
 | `NUXT_PUBLIC_TALKTOME_BRIDGE_ENABLED` | value of `TALKTOME_BRIDGE_ENABLED` | Browser-visible runtime gate; compose derives it from the server gate |
 | `TALKTOME_BASE_URL` | empty | talktome base URL; required only when the bridge is enabled |
-| `TALKTOME_BRIDGE_ID` | empty | Stable bridge ID; required only when enabled |
+| `TALKTOME_BRIDGE_ID` | empty | Optional bridge registration id; when unset, a UUID is generated once and persisted next to the mapping config |
 | `TALKTOME_BRIDGE_TOKEN` | empty | Protected bridge/API credential; required only when enabled |
 | `TALKTOME_MEDIA_ANNOUNCE_IP` | empty | Reachable Docker-host media address; required only when enabled |
 | `TALKTOME_BRIDGE_CONFIG_PATH` | `/config/talktome-bridge.json` | Persistent per-account mapping file |

--- a/docs/mediasoup-bridge.md
+++ b/docs/mediasoup-bridge.md
@@ -87,7 +87,7 @@ receives no API credentials.
 | `TALKTOME_BRIDGE_ENABLED` | `false` | Yes | Global hard gate. Set exactly `true` to enable. Compose also passes this non-secret value to baresip as a recreation marker. |
 | `NUXT_PUBLIC_TALKTOME_BRIDGE_ENABLED` | server gate value | Yes | Browser runtime gate. Compose derives it from `TALKTOME_BRIDGE_ENABLED`; it contains no secret. |
 | `TALKTOME_BASE_URL` | empty | Yes | talktome origin/base URL. Prefer HTTPS and do not embed credentials in it. |
-| `TALKTOME_BRIDGE_ID` | empty | Yes | Stable ID of this bridge registration. |
+| `TALKTOME_BRIDGE_ID` | empty | No | Optional explicit bridge registration id. When unset, the app generates a UUID once and persists it beside the mapping config as `talktome-bridge.identity.json` (same idea as the official bridge-client storing `bridge.id` in localStorage). Set this only to pin/reuse a known id across hosts. |
 | `TALKTOME_BRIDGE_TOKEN` | empty | Yes | Bridge bearer token or suitably scoped API credential. |
 | `TALKTOME_MEDIA_ANNOUNCE_IP` | empty | Yes | Address through which talktome can reach the Docker host's published bridge RTP ports. |
 | `TALKTOME_BRIDGE_CONFIG_PATH` | `/config/talktome-bridge.json` | No | Persistent per-account mapping file. Keep it on the mounted config volume. |
@@ -105,9 +105,30 @@ explicitly default the global gate to `false`. They derive the browser-safe
 `NUXT_PUBLIC_TALKTOME_BRIDGE_ENABLED` override from that same value and pass
 only the non-secret gate to `baresip`, solely so Compose detects gate changes
 and recreates the process that may contain a dynamically loaded module.
-Configure the four required connection values before setting the gate to
-`true`. A partially configured enabled deployment fails the bridge plugin
-closed.
+Configure the three required connection values (`TALKTOME_BASE_URL`,
+`TALKTOME_BRIDGE_TOKEN`, `TALKTOME_MEDIA_ANNOUNCE_IP`) before setting the gate
+to `true`. `TALKTOME_BRIDGE_ID` is optional (see Bridge ID below). A partially
+configured enabled deployment fails the bridge plugin closed.
+
+### Bridge ID (optional)
+
+TalkToMe Admin does not surface an easy copy-paste bridge id for operators.
+The official `bridge-client` therefore omits the id on first announce (the
+server assigns a UUID) and persists `bridge.id` for later re-announces.
+
+This app mirrors that UX without requiring Admin lookup:
+
+1. If `TALKTOME_BRIDGE_ID` is set, that value is used and written to the
+   identity file.
+2. Else if `<config-basename>.identity.json` next to
+   `TALKTOME_BRIDGE_CONFIG_PATH` already contains a `bridgeId`, that value is
+   reused (default path: `/config/talktome-bridge.identity.json`).
+3. Else the app generates a UUID, persists it, and announces with it.
+
+Successful announce responses also refresh the persisted id from
+`bridge.id`, matching the official client. Keep the identity file on the same
+mounted config volume as the account mappings so the registration stays stable
+across container recreations. The id is not a secret; the bridge token is.
 
 ### Compatibility and server version warning
 
@@ -184,12 +205,15 @@ For a short local ctrl_tcp diagnostic, use a temporary Compose override with
 
 1. Configure the talktome mediasoup worker's `RTC_PORT_RANGE` and
    `announcedIp`. Open that UDP range on the talktome server.
-2. Create a stable bridge ID and announce/register the bridge through the
-   Bridge API. talktome **v1.1.1+** marks a bridge stale after ~45 seconds
-   without a fresh `POST /api/v1/bridge/announce`; this agent re-announces
-   every 10 seconds (same cadence as the official bridge-client). Session
-   SSE/heartbeat keep *sessions* alive, not the registry row in Admin →
-   Status → Bridge Instances.
+2. Leave `TALKTOME_BRIDGE_ID` unset unless you need to pin a specific id.
+   On first start the app generates a UUID and stores it in
+   `talktome-bridge.identity.json` on the config volume (same pattern as the
+   official bridge-client persisting `bridge.id`). Announce/register with the
+   Bridge API using that id. talktome **v1.1.1+** marks a bridge stale after
+   ~45 seconds without a fresh `POST /api/v1/bridge/announce`; this agent
+   re-announces every 10 seconds (same cadence as the official bridge-client).
+   Session SSE/heartbeat keep *sessions* alive, not the registry row in
+   Admin → Status → Bridge Instances.
 3. Store the resulting matching bridge token securely for the app service.
 4. Create one dedicated talktome user per bridged SIP account.
 5. Assign each talktome user as a `user` endpoint or each feed as a `feed`

--- a/server/plugins/talktome-bridge.ts
+++ b/server/plugins/talktome-bridge.ts
@@ -4,6 +4,7 @@ import {
   TalktomeBridgeRuntime,
   setTalktomeBridgeRuntime,
 } from '../services/talktome/runtime';
+import { resolveTalktomeBridgeId } from '../services/talktome/bridge-identity';
 import { readTalktomeBridgeEnvironment } from '../services/talktome/env';
 import { getTalktomeBridgeConfigManager } from '../services/talktome-bridge-config';
 import { recoverTalktomeMappingJournal } from '../services/talktome/transaction-journal';
@@ -66,6 +67,42 @@ export default defineNitroPlugin(async (nitroApp) => {
     return;
   }
 
+  let bridgeId: string;
+  try {
+    const resolved = await resolveTalktomeBridgeId({
+      configuredId: environment.bridgeId,
+      configPath: environment.configPath,
+    });
+    bridgeId = resolved.bridgeId;
+    if (resolved.source === 'generated') {
+      stateManager.addLog(
+        'info',
+        'talktome-bridge',
+        `Generated and persisted talktome bridge id ${bridgeId} at ${resolved.identityPath}`,
+      );
+    } else if (resolved.source === 'persisted') {
+      stateManager.addLog(
+        'info',
+        'talktome-bridge',
+        `Using persisted talktome bridge id ${bridgeId}`,
+      );
+    }
+  } catch (error) {
+    const message = `Talktome bridge id resolution failed: ${
+      error instanceof Error ? error.message : String(error)
+    }`;
+    stateManager.setTalktomeBridgeGlobalStatus({
+      enabled: true,
+      phase: 'failed',
+      baresipConnected: stateManager.getBaresipConnected(),
+      serverReachable: false,
+      lastError: message,
+      updatedAt: Date.now(),
+    });
+    stateManager.addLog('error', 'talktome-bridge', message);
+    return;
+  }
+
   try {
     const config = useRuntimeConfig();
     const connection = getBaresipConnection(
@@ -75,7 +112,7 @@ export default defineNitroPlugin(async (nitroApp) => {
     const runtime = new TalktomeBridgeRuntime({
       connection,
       baseUrl: environment.baseUrl,
-      bridgeId: environment.bridgeId,
+      bridgeId,
       token: environment.token,
       mediaAnnounceIp: environment.mediaAnnounceIp,
       configPath: environment.configPath,

--- a/server/services/talktome/bridge-identity.ts
+++ b/server/services/talktome/bridge-identity.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export type TalktomeBridgeIdSource = 'env' | 'persisted' | 'generated';
+
+export interface ResolvedTalktomeBridgeId {
+  bridgeId: string;
+  source: TalktomeBridgeIdSource;
+  identityPath: string;
+}
+
+/**
+ * Sibling of the account-mapping config, e.g.
+ * `/config/talktome-bridge.json` → `/config/talktome-bridge.identity.json`.
+ * Matches the official bridge-client pattern of persisting the opaque bridge
+ * id across restarts (localStorage there; config volume here).
+ */
+export function talktomeBridgeIdentityPath(configPath: string): string {
+  if (!path.isAbsolute(configPath)) {
+    throw new Error('Talktome bridge config path must be absolute');
+  }
+  const directory = path.dirname(configPath);
+  const base = path.basename(configPath, path.extname(configPath));
+  return path.join(directory, `${base}.identity.json`);
+}
+
+/**
+ * Resolve the stable TalkToMe bridge registration id:
+ * 1. `TALKTOME_BRIDGE_ID` when set (explicit override)
+ * 2. previously persisted identity next to the bridge config
+ * 3. otherwise generate a UUID and persist it
+ *
+ * The official talktome bridge-client likewise does not require operators to
+ * copy an id from Admin: first announce may omit the id (server assigns a
+ * UUID) and the client stores `bridge.id` for later re-announces. We generate
+ * the UUID locally up front so ctrl_tcp/runtime validation always has a
+ * non-empty id before the first announce.
+ */
+export async function resolveTalktomeBridgeId(options: {
+  configuredId: string;
+  configPath: string;
+}): Promise<ResolvedTalktomeBridgeId> {
+  const identityPath = talktomeBridgeIdentityPath(options.configPath);
+  const fromEnv = options.configuredId.trim();
+  if (fromEnv) {
+    await writeBridgeIdentity(identityPath, fromEnv);
+    return { bridgeId: fromEnv, source: 'env', identityPath };
+  }
+
+  const persisted = await readBridgeIdentity(identityPath);
+  if (persisted) {
+    return { bridgeId: persisted, source: 'persisted', identityPath };
+  }
+
+  const generated = randomUUID();
+  await writeBridgeIdentity(identityPath, generated);
+  return { bridgeId: generated, source: 'generated', identityPath };
+}
+
+/**
+ * Persist the id returned by TalkToMe announce (`bridge.id`), matching the
+ * official bridge-client localStorage update after each successful announce.
+ */
+export async function persistAnnouncedBridgeId(options: {
+  configPath: string;
+  bridgeId: string;
+}): Promise<string> {
+  const bridgeId = options.bridgeId.trim();
+  if (!bridgeId) {
+    throw new Error('Announced talktome bridge id must be non-empty');
+  }
+  const identityPath = talktomeBridgeIdentityPath(options.configPath);
+  await writeBridgeIdentity(identityPath, bridgeId);
+  return bridgeId;
+}
+
+async function readBridgeIdentity(identityPath: string): Promise<string | undefined> {
+  try {
+    const contents = await fs.readFile(identityPath, 'utf8');
+    const parsed = JSON.parse(contents) as unknown;
+    if (!isRecord(parsed)) return undefined;
+    const bridgeId =
+      typeof parsed.bridgeId === 'string' ? parsed.bridgeId.trim() : '';
+    return bridgeId || undefined;
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return undefined;
+    if (error instanceof SyntaxError) {
+      throw new Error(
+        `Talktome bridge identity file is not valid JSON: ${error.message}`,
+      );
+    }
+    throw error;
+  }
+}
+
+async function writeBridgeIdentity(
+  identityPath: string,
+  bridgeId: string,
+): Promise<void> {
+  const directory = path.dirname(identityPath);
+  await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = path.join(
+    directory,
+    `.${path.basename(identityPath)}.${process.pid}.${Date.now()}.${
+      Math.random().toString(16).slice(2)
+    }.tmp`,
+  );
+
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  try {
+    handle = await fs.open(temporaryPath, 'wx', 0o600);
+    await handle.writeFile(
+      `${JSON.stringify({ bridgeId }, null, 2)}\n`,
+      'utf8',
+    );
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await fs.rename(temporaryPath, identityPath);
+    await fs.chmod(identityPath, 0o600);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await fs.unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/server/services/talktome/index.ts
+++ b/server/services/talktome/index.ts
@@ -6,3 +6,4 @@ export * from './module-controller';
 export * from './orchestrator';
 export * from './runtime';
 export * from './env';
+export * from './bridge-identity';

--- a/server/services/talktome/runtime.ts
+++ b/server/services/talktome/runtime.ts
@@ -30,6 +30,7 @@ import {
 import type { BridgeRuntimeConfig, JsonObject } from './types';
 import { buildVirtualBridgeInventory } from './virtual-inventory';
 import { withTalktomeAccountLifecycleLock } from './account-lifecycle-lock';
+import { persistAnnouncedBridgeId } from './bridge-identity';
 import {
   DEFAULT_TALKTOME_TESTED_VERSION,
   isTalktomeServerNewerThanTested,
@@ -295,6 +296,16 @@ export class TalktomeBridgeRuntime {
           onTally: (update) => this.handleTally(update),
           onAnnouncement: (announcement) => {
             this.remoteConfig = announcement.config;
+            const announcedId =
+              typeof announcement.bridge?.id === 'string'
+                ? announcement.bridge.id.trim()
+                : '';
+            if (announcedId) {
+              void persistAnnouncedBridgeId({
+                configPath: this.options.configPath,
+                bridgeId: announcedId,
+              }).catch((error) => this.reportError(error));
+            }
             // Periodic announce keep-alives should not re-hit /health when the
             // server still omits appVersion (talktome v1.1.3). Only refresh when
             // announce itself carries a version; startup probes once below.
@@ -685,7 +696,6 @@ export function getTalktomeBridgeRuntime(): TalktomeBridgeRuntime | undefined {
 function validateOptions(options: TalktomeBridgeRuntimeOptions): void {
   const required: Array<[string, string]> = [
     ['TALKTOME_BASE_URL', options.baseUrl],
-    ['TALKTOME_BRIDGE_ID', options.bridgeId],
     ['TALKTOME_BRIDGE_TOKEN', options.token],
     ['TALKTOME_MEDIA_ANNOUNCE_IP', options.mediaAnnounceIp],
   ];
@@ -694,6 +704,9 @@ function validateOptions(options: TalktomeBridgeRuntimeOptions): void {
     .map(([name]) => name);
   if (missing.length) {
     throw new Error(`Missing required talktome environment: ${missing.join(', ')}`);
+  }
+  if (!options.bridgeId?.trim()) {
+    throw new Error('Talktome bridgeId is required (set TALKTOME_BRIDGE_ID or persist an identity)');
   }
   if (isIP(options.mediaAnnounceIp.trim()) === 0) {
     throw new Error('TALKTOME_MEDIA_ANNOUNCE_IP must be an IPv4 or IPv6 address');

--- a/test/talktome-bridge-identity.test.ts
+++ b/test/talktome-bridge-identity.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  persistAnnouncedBridgeId,
+  resolveTalktomeBridgeId,
+  talktomeBridgeIdentityPath,
+} from '~/server/services/talktome/bridge-identity';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function tempConfigPath(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'talktome-bridge-id-'));
+  tempDirs.push(dir);
+  return path.join(dir, 'talktome-bridge.json');
+}
+
+describe('talktome bridge identity', () => {
+  it('maps the identity file beside the mapping config path', () => {
+    expect(talktomeBridgeIdentityPath('/config/talktome-bridge.json')).toBe(
+      '/config/talktome-bridge.identity.json',
+    );
+  });
+
+  it('prefers TALKTOME_BRIDGE_ID and persists it for later runs', async () => {
+    const configPath = await tempConfigPath();
+    const first = await resolveTalktomeBridgeId({
+      configuredId: ' bridge-explicit ',
+      configPath,
+    });
+    expect(first).toMatchObject({
+      bridgeId: 'bridge-explicit',
+      source: 'env',
+    });
+
+    const stored = JSON.parse(
+      await readFile(first.identityPath, 'utf8'),
+    ) as { bridgeId: string };
+    expect(stored.bridgeId).toBe('bridge-explicit');
+
+    const second = await resolveTalktomeBridgeId({
+      configuredId: '',
+      configPath,
+    });
+    expect(second).toMatchObject({
+      bridgeId: 'bridge-explicit',
+      source: 'persisted',
+    });
+  });
+
+  it('generates a UUID once and reuses the persisted value', async () => {
+    const configPath = await tempConfigPath();
+    const first = await resolveTalktomeBridgeId({
+      configuredId: '',
+      configPath,
+    });
+    expect(first.source).toBe('generated');
+    expect(first.bridgeId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+
+    const second = await resolveTalktomeBridgeId({
+      configuredId: '',
+      configPath,
+    });
+    expect(second).toMatchObject({
+      bridgeId: first.bridgeId,
+      source: 'persisted',
+    });
+  });
+
+  it('updates the persisted id from a successful announce response', async () => {
+    const configPath = await tempConfigPath();
+    await writeFile(
+      talktomeBridgeIdentityPath(configPath),
+      `${JSON.stringify({ bridgeId: 'local-generated' }, null, 2)}\n`,
+      'utf8',
+    );
+
+    const announced = await persistAnnouncedBridgeId({
+      configPath,
+      bridgeId: ' server-assigned-id ',
+    });
+    expect(announced).toBe('server-assigned-id');
+
+    const resolved = await resolveTalktomeBridgeId({
+      configuredId: '',
+      configPath,
+    });
+    expect(resolved).toMatchObject({
+      bridgeId: 'server-assigned-id',
+      source: 'persisted',
+    });
+  });
+});


### PR DESCRIPTION
TALKTOME_BRIDGE_ID is optional. When unset, generate a UUID once and store it beside the mapping config (talktome-bridge.identity.json), matching the official bridge-client identity persistence pattern.